### PR TITLE
EIGHTEENF-13: Chart Not Refreshing

### DIFF
--- a/WebContent/js/consumer.js
+++ b/WebContent/js/consumer.js
@@ -311,6 +311,7 @@ function initializeBreadCrumbs() {
 
 
 function renderGraph(dataForGraph) {
+	$(".chart").html("");
 	$(".placeholder").css("display","none");
 	$("#ajaxErrorNoReturnData").css("display","none");
 	$(".chart").fadeIn();


### PR DESCRIPTION
EIGHTEENF-13: a bug - chart not refreshing after the second time, "generate chart" is clicked - was resolved by clearing the chart area first and then loading the new chart.
